### PR TITLE
Erased Database and re-migrated

### DIFF
--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,9 +1,43 @@
-<h1>StaticPages#home</h1>
-<p>Find me in app/views/static_pages/home.html.erb</p>
-  <%= link_to 'Go to Database', admin_dashboard_path %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>ASIG v2</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+<link href="https://fonts.googleapis.com/css?family=Special+Elite"rel="stylesheet" type="text/css">
+<link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  <style>
+
+  h1 {
+      margin: 10px 30px;
+      text-align: center;
+      letter-spacing: 10px;      
+      font-size: 25px;
+      color: #777;
+      font-family="Special Elite", serif
+  }
+  h3, h4 {
+      text-align: center;
+      letter-spacing: 5px;  
+      font-size: 15px;
+      font-family="Lato", sans serif
+      color: #777;
+  }
+</style>
+</head>
+<body data-offset="50">
+
+<h1>The Archaeological Site Inventory for Grenada (ASIG), v.2 </h1>
+<br>
+ <h3> <%= link_to 'Go to Database', admin_dashboard_path %>
   <br/>
 <% if current_user %>
   <%= link_to 'logout', destroy_user_session_path, method: 'delete' %>
 <% else %>
+<br>
   <%= link_to 'login', new_user_session_path %>
+  </h3>
 <% end %>

--- a/db/migrate/20170505194719_create_active_admin_comments.rb
+++ b/db/migrate/20170505194719_create_active_admin_comments.rb
@@ -1,5 +1,5 @@
 class CreateActiveAdminComments < ActiveRecord::Migration
-  drop_table(:active_admin_comments, if_exists: true)
+  #drop_table(:active_admin_comments, if_exists: true)
   def self.up
     create_table :active_admin_comments do |t|
       t.string :namespace

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -108,13 +108,6 @@ ActiveRecord::Schema.define(version: 20170624224103) do
   add_index "ceramic_types", ["description"], name: "index_ceramic_types_on_description", using: :btree
   add_index "ceramic_types", ["name"], name: "index_ceramic_types_on_name", using: :btree
 
-  create_table "ceramic_typologies", force: :cascade do |t|
-    t.integer  "archeological_site_id"
-    t.integer  "ceramic_types_id"
-    t.datetime "created_at",            null: false
-    t.datetime "updated_at",            null: false
-  end
-
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer  "priority",   default: 0, null: false
     t.integer  "attempts",   default: 0, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -92,7 +92,7 @@ if Rails.env.development?
     site.ceramic_types = CeramicType.all.sample(rand(CeramicType.count + 1))
     site.ceramic_diagnostics = CeramicDiagnostic.all.sample(
       rand(CeramicDiagnostic.count + 1))
-    site.previous_work = PreviousWork.all.sample(rand(PreviousWork.count + 1))
+    site.previous_works = PreviousWork.all.sample(rand(PreviousWork.count + 1))
     site.threats = Threat.all.sample(rand(Threat.count + 1))
     site.save
   end


### PR DESCRIPTION
Had a hell of a time trying to import my tables. A variety of things went wrong, including the UTF-8 issue. Here is a breakdown:

JUMBLED TABLES
After trying to import my csv so many times, I had a ton of messed-up entries. I just wanted to overwrite everything with a new table. I'm still not sure how to do that, but I ended up deleting everything by running:

rake db:drop 
db:create 
db:migrate 

When I got to the migrate step, though, it said various active_admin tables did not exist (they were in migrate. So then I tried
rake db:migrate VERSION=0  

which I think erased schema.rb and screwed everything up (!). When I replaced it with the previous schema.rb, I could run the front-end web interface, but there weren't any users. So, I decided to just reimport everything in the develop branch on github and redo the last few changes I had made for the UTF-8 thing. 

UFT-8 ISSUES
Aside from the character issues that had to be fixed (I used notepad++ to convert from ASCII), there was also the problem of line breaks within long entries in the database (e.g., my "summaries" sections). To fix that, I followed this guy's recommendation: https://nicercode.github.io/blog/2013-04-30-excel-and-line-endings/  This basically added a gitattributes file that read /n as a line break

Now everything is working again, but I'm back to jumbled tables. The next step is to fix my csv file and try importing again...